### PR TITLE
Retrieve all dependencies of a package

### DIFF
--- a/src/o2wCache.ml
+++ b/src/o2wCache.ml
@@ -1,0 +1,62 @@
+(**************************************************************************)
+(*                                                                        *)
+(*    Copyright 2012-2018 OCamlPro                                        *)
+(*    Copyright 2012 INRIA                                                *)
+(*                                                                        *)
+(*  All rights reserved.This file is distributed under the terms of the   *)
+(*  GNU Lesser General Public License version 3.0 with linking            *)
+(*  exception.                                                            *)
+(*                                                                        *)
+(*  OPAM is distributed in the hope that it will be useful, but WITHOUT   *)
+(*  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY    *)
+(*  or FITNESS FOR A PARTICULAR PURPOSE.See the GNU General Public        *)
+(*  License for more details.                                             *)
+(*                                                                        *)
+(**************************************************************************)
+
+type 'a t = {
+  file: OpamFilename.t;
+  version: Digest.t;
+  default: 'a
+}
+
+let cache ~version file default =
+  let version =
+    Digest.string (OpamVersion.(to_string (full ())) ^" "^
+                   string_of_int version)
+  in
+  let file = OpamFilename.of_string file in
+  { file; version; default}
+
+let write_cache (drop: 'a) (cache: 'a t) =
+  OpamFilename.mkdir (OpamFilename.dirname cache.file);
+  let oc = open_out_bin (OpamFilename.to_string cache.file) in
+  Digest.output oc cache.version;
+  Marshal.to_channel oc drop [];
+  close_out oc
+
+let read_cache_opt cache =
+  try
+    let ic = open_in_bin (OpamFilename.to_string cache.file) in
+    let stored =
+      if Digest.input ic = cache.version then
+        (Printf.printf "Reading logs cache from %s... %!"
+           (OpamFilename.to_string cache.file);
+         let timer = OpamConsole.timer () in
+         let c = Marshal.from_channel ic in
+         Printf.printf "done (%.3fs).\n%!" (timer ());
+         Some c)
+      else
+        (Printf.printf "Skipping mismatching logs cache %s\n%!"
+           (OpamFilename.to_string cache.file);
+         None)
+    in
+    close_in ic;
+    stored
+  with _ -> None
+
+let read_cache cache =
+  match read_cache_opt cache with
+  | Some c -> c
+  | None -> cache.default
+

--- a/src/o2wCache.mli
+++ b/src/o2wCache.mli
@@ -1,0 +1,25 @@
+(**************************************************************************)
+(*                                                                        *)
+(*    Copyright 2012-2018 OCamlPro                                        *)
+(*    Copyright 2012 INRIA                                                *)
+(*                                                                        *)
+(*  All rights reserved.This file is distributed under the terms of the   *)
+(*  GNU Lesser General Public License version 3.0 with linking            *)
+(*  exception.                                                            *)
+(*                                                                        *)
+(*  OPAM is distributed in the hope that it will be useful, but WITHOUT   *)
+(*  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY    *)
+(*  or FITNESS FOR A PARTICULAR PURPOSE.See the GNU General Public        *)
+(*  License for more details.                                             *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Caches *)
+
+type 'a t
+
+val cache: version:int -> string -> 'a -> 'a t
+
+val write_cache: 'a -> 'a t -> unit
+
+val read_cache: 'a t -> 'a

--- a/src/o2wStatistics.mli
+++ b/src/o2wStatistics.mli
@@ -26,6 +26,9 @@ val statistics_set: filename list -> dirname list -> statistics_set option
 val top_packages: ?ntop:int -> ?reverse:bool -> (package -> 'a) ->
   package_set -> (package * 'a) list
 
+(** Generate package dependencies cache of given repos *)
+val generate_dependencies_cache: dirname list -> unit
+
 (** Export the popularity list into CSV format *)
 val to_csv: int64 package_map -> string -> unit
 


### PR DESCRIPTION
For most popular calculation, we use the leaf packages stats, and for that we retrieve dependencies and remove them in a window of 2 minutes (cf. c79bcc7). We used opam file depends to retrieve dependencies, instead of computing the all dependencies. That's how it is done in this PR.
As calculating it for all package is time consuming (takes 1h for all opam-repo), a cache is required, that can be generated using `--generate-dcache` option. 
In case the cache is non existent, it is the old behavior that is used.