### PR TITLE
Added alt text to the images at the footer on opam.ocaml.org

### DIFF
--- a/src/o2wTemplate.ml
+++ b/src/o2wTemplate.ml
@@ -157,13 +157,13 @@ let make_footer srcurl depth =
     (Html.div ~cls:"icons"
        (Html.div ~cls:"icon"
           (Html.a ~href:(Uri.of_string "https://github.com/ocaml/opam2web")
-             (Html.img (icon "github.png"))) (* FIXME: icon : Uri.t *)
+             (Html.img (icon "github.png") ~alt:"Find us on GitHub")) (* FIXME: icon : Uri.t *)
         @ Html.div ~cls:"icon"
             (Html.a ~href:(Uri.of_string "http://www.ocamlpro.com/")
-               (Html.img (icon "ocamlpro.png")))
+               (Html.img (icon "ocamlpro.png") ~alt:"Go to OCamlPro.com"))
         @ Html.div ~cls:"icon"
             (Html.a ~href:(Uri.of_string "http://www.ocaml.org/")
-               (Html.img (icon "ocaml.png"))))
+               (Html.img (icon "ocaml.png") ~alt:"Go to OCaml.org")))
      @ Html.div ~cls:"copyright"
          (Html.small
             (Html.string "Generated " @ srcurl


### PR DESCRIPTION
Hey! @avsm 
I am an outreachy applicant and I am aware that this repository is not for us applicants.
However, I'm still learning OCaml and I think I'm very close to finding the solution to issue  [#1328](https://github.com/ocaml/ocaml.org/issues/1328) on ocaml.org repository.
I am not able to build the site locally only on this opam2web repository even after [discussing](https://discuss.ocaml.org/t/getting-dependency-error-on-running-opam-install-opam2web/7730/1) hence, I am unable to find out what does my contribution look like.
Could you please review it and help me out?
Thanks!