### PR TITLE
Fix the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN apk add git curl rsync libstdc++
 COPY --from=build-opam2web /opt/opam2web /usr/local
 COPY --from=build-opam-doc /usr/bin/opam /usr/local/bin/opam
 COPY --from=build-opam-doc /opt/opam/doc /usr/local/share/opam2web/content/doc
-ADD scripts/opam-web.sh /usr/local/bin
+ADD bin/opam-web.sh /usr/local/bin
 VOLUME ["/www"]
 RUN addgroup -g 82 -S www-data && adduser -u 82 -D -S -G www-data www-data
 USER www-data

--- a/bin/opam-web.sh
+++ b/bin/opam-web.sh
@@ -37,12 +37,12 @@ fi
 # Overwrite 'repo' file, and dispatch all non-standard versions
 cat <<EOF >repo
 opam-version: "2.0"
-browse: "https://opam.ocaml.org/pkg/"
+browse: "https://${BASEURL}/pkg/"
 upstream: "https://github.com/ocaml/opam-repository/tree/master/"
 redirect: [
-  "${URL}1.1" { opam-version < "1.2" }
-  "${URL}1.2.0" { opam-version < "1.2.2" }
-  "${URL}1.2.2" { opam-version < "2.0~" }
+  "https://${BASEURL}/1.1" { opam-version < "1.2" }
+  "https://${BASEURL}/1.2.0" { opam-version < "1.2.2" }
+  "https://${BASEURL}/1.2.2" { opam-version < "2.0~" }
 ]
 EOF
 mkdir -p /persist/repo-cache/archives


### PR DESCRIPTION
Was failing on `Cannot find scripts/opam-web.sh` and on:
```
 => ERROR [opam2web 9/9] RUN --mount=type=cache,target=/persist,uid=82,gid=82 opam-web.sh opam.ocaml.org                                                                                              47.1s
------
 > [opam2web 9/9] RUN --mount=type=cache,target=/persist,uid=82,gid=82 opam-web.sh opam.ocaml.org:
#44 0.485 + BASEURL=opam.ocaml.org
#44 0.485 + shift
#44 0.485 + '[' 0 -eq 0 ]
#44 0.485 + cd /persist
#44 0.485 + '[' -d opam-repository ]
#44 0.486 + git clone https://github.com/ocaml/opam-repository opam-repository --bare --single-branch --branch master
#44 0.493 Cloning into bare repository 'opam-repository'...
#44 40.69 + '[' -d blog ]
#44 40.69 + git clone https://github.com/ocaml/platform-blog blog --bare --single-branch --branch master
#44 40.69 Cloning into bare repository 'blog'...
#44 41.65 + cd /www
#44 41.65 + '[' -d .git ]
#44 41.65 + git clone -s /persist/opam-repository .
#44 41.65 Cloning into '.'...
#44 41.66 done.
Updating files: 100% (22418/22418), done.8)
#44 45.97 /usr/local/bin/opam-web.sh: line 38: URL: parameter not set
```