### PR TITLE
Follow the platform blog.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,8 +54,10 @@ COPY ext/key/opam-dev-team.pgp /www/opam-dev-pubkey.pgp
 ADD bin/opam-web.sh /usr/local/bin
 ARG DOMAIN=opam.ocaml.org
 ARG OPAM_GIT_SHA
+ARG BLOG_GIT_SHA
 RUN echo ${OPAM_GIT_SHA} >> /www/opam_git_sha
-RUN /usr/local/bin/opam-web.sh ${DOMAIN} ${OPAM_GIT_SHA}
+RUN echo ${BLOG_GIT_SHA} >> /www/blog_git_sha
+RUN /usr/local/bin/opam-web.sh ${DOMAIN} ${OPAM_GIT_SHA} ${BLOG_GIT_SHA}
 
 FROM caddy:alpine
 WORKDIR /srv

--- a/bin/opam-web.sh
+++ b/bin/opam-web.sh
@@ -2,13 +2,14 @@
 
 set -uex
 
-if [[ $# -eq 3 ]] ; then
-    echo 'Usage: $0 BASEURL OPAM_GIT_SHA'
+if [[ $# -eq 4 ]] ; then
+    echo 'Usage: $0 BASEURL OPAM_GIT_SHA BLOG_GIT_SHA'
     exit 2
 fi
 
 BASEURL=$1
-OPAM_GIT_SHA=$2 
+OPAM_GIT_SHA=$2
+BLOG_GIT_SHA=$3
 
 cd /www
 # Checkout a specific commit as supplied by ocurrent-deployer pipeline.
@@ -36,7 +37,10 @@ opam admin cache --link=archives ./cache
 opam admin index --minimal-urls-txt
 
 cp -r /usr/local/share/opam2web/content /tmp/
-git clone https://github.com/ocaml/platform-blog --single-branch --branch master /tmp/content/blog
+git clone https://github.com/ocaml/platform-blog --single-branch --branch master /tmp/content/blog &&
+    cd /tmp/content/blog &&
+    git checkout ${BLOG_GIT_SHA} &&
+    cd -
 
 rm -rf /www/ext
 mkdir -p /www/ext


### PR DESCRIPTION
occurrent-deployer pipeline will follow both [ocaml/opam-repository](https://github.com/ocaml/opam-repository) and [platform-blog](https://github.com/ocaml/platform-blog), triggering a rebuild of the opam.ocaml.org docker image if either of them changes. This is currently running on my fork at https://deploy.ci.ocaml.org/?repo=tmcgilchrist/opam2web

Matching ocurrent-deployer PR https://github.com/ocurrent/ocurrent-deployer/pull/107
