### PR TITLE
Pin to specific version of caddy with alpine.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ RUN echo ${OPAM_GIT_SHA} >> /www/opam_git_sha
 RUN echo ${BLOG_GIT_SHA} >> /www/blog_git_sha
 RUN /usr/local/bin/opam-web.sh ${DOMAIN} ${OPAM_GIT_SHA} ${BLOG_GIT_SHA}
 
-FROM caddy:alpine
+FROM caddy:2.5.2-alpine
 WORKDIR /srv
 COPY --from=opam2web /www /usr/share/caddy
 ENTRYPOINT ["caddy", "file-server"]


### PR DESCRIPTION
Perhaps this is useful to isolate the SEGV error we are seeing.
The caddy image changed the major version to 2.6 from 2.5.2 in the last 11 hours.

@dra27 