### PR TITLE
Pin caddy version to 2.5.2

### DIFF
--- a/Dockerfile.image
+++ b/Dockerfile.image
@@ -1,7 +1,7 @@
 # syntax = docker/dockerfile:1.0.2-experimental
 FROM opam-website-data
 FROM ocaml/opam.ocaml.org-legacy
-FROM caddy:alpine
+FROM caddy:2.5.2-alpine
 WORKDIR /srv
 COPY --from=0 . /srv
 COPY --from=1 . /srv


### PR DESCRIPTION
There is a know bug in caddy 2.6 docker images https://github.com/caddyserver/caddy/issues/5058
Pinning to the last know good version of caddy to avoid this.