### PR TITLE
Package pages: do not display reverse conflicts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.3
 FROM ocaml/opam:alpine-3.15-ocaml-4.14 as build-opam2web
 RUN sudo apk add g++ gmp-dev
-RUN git clone https://github.com/ocaml/opam2web.git --depth 1 /home/opam/opam2web
+COPY . /home/opam/opam2web
 WORKDIR /home/opam/opam2web
 ENV OCAMLRUNPARAM b
 RUN sudo mkdir -p /opt/opam2web && sudo chown opam:opam /opt/opam2web

--- a/src/o2wPackage.ml
+++ b/src/o2wPackage.ml
@@ -308,26 +308,7 @@ let to_html ~prefix univ pkg =
     | f -> Some ("Optional dependencies", or_formula f)
   in
   let pkg_conflicts =
-    let conflicts =
-      OpamSwitchState.conflicts_with univ.st (OpamPackage.Set.singleton pkg)
-        univ.st.packages
-    in
-    let cf =
-      OpamPackage.Name.Map.fold
-        (fun name versions acc ->
-           let cstr =
-             OpamFormula.formula_of_version_set
-               (OpamPackage.versions_of_name univ.st.packages name)
-               versions |>
-             OpamFormula.map (fun (op,v) ->
-                 Atom (Constraint (op,
-                                   FString (OpamPackage.Version.to_string v))))
-           in
-           OpamFormula.ors [acc; Atom (name, cstr)])
-        (OpamPackage.to_map conflicts)
-        OpamFormula.Empty
-    in
-    match cf with
+    match OpamFile.OPAM.conflicts pkg_opam with
     | Empty -> None
     | f -> Some ("Conflicts", or_formula f)
   in


### PR DESCRIPTION
A conflict between A and B can happen because of several things:
- B is listed in the `conflicts` field of A
- A is listed in the `conflicts` field of B
- A and B share a `conflict-class`

In the package page, opam2web displays conflicts in a global way: it loads all the universe, and determines which packages conflicts with it (for whichever of the above reasons).

The problem with this approach is that it is slow: it requires analyzing the universe, for each package.

This commit does something simpler: it just displays the metadata corresponding to the package rendered on the current page. This is consistent with how `ocaml.org` now renders package metadata.

For an example of changed behaviour: `dune.3.12.2` declares a conflict against old versions of `merlin`. the old behaviour would display a `dune` conflict on the `merlin.3.3.9` page.

This creates a huge speedup: a 2077s job now takes 183s (11.3 times faster).
