### PR TITLE
Dockerfile maintenance updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,9 @@ COPY --chown=opam:opam . /home/opam/opam2web
 WORKDIR /home/opam/opam2web
 ENV OCAMLRUNPARAM b
 RUN sudo mkdir -p /opt/opam2web && sudo chown opam:opam /opt/opam2web
-RUN sudo mv /usr/bin/opam-2.1 /usr/bin/opam && opam update
+RUN sudo mv /usr/bin/opam-2.2 /usr/bin/opam && opam update
 RUN opam repo set-url default git+https://github.com/ocaml/opam-repository.git#${OPAM_REPO_GIT_SHA}
+ENV OPAMSOLVERTIMEOUT 120
 RUN opam install . --destdir /opt/opam2web
 RUN cp -r content /opt/opam2web/share/opam2web/
 RUN rm -rf /opt/opam2web/share/opam2web/lib
@@ -30,7 +31,7 @@ RUN sudo mkdir -p /usr/local/bin \
                 echo "</BODY></HTML>\n' \
        | sudo tee /usr/local/bin/man2html \
     && sudo chmod a+x /usr/local/bin/man2html
-RUN sudo mv /usr/bin/opam-2.1 /usr/bin/opam && opam update
+RUN sudo mv /usr/bin/opam-2.2 /usr/bin/opam && opam update
 RUN opam install odoc
 RUN git clone https://github.com/ocaml/opam --single-branch --depth 1 --branch master /home/opam/opam
 WORKDIR /home/opam/opam


### PR DESCRIPTION
* Update Dockerfile to us Alpine 3.20.
* Update the `build-opam2web` step to use opam 2.1 as per the other steps. The performance improvements in opam 2.1 over 2.0 mean that the timeout added as a hotfix in #237 is no longer needed.
* Update Dockerfile to Caddy 2.8.4 (which is built on Alpine 3.20). It may be worth considering using `caddy:latest` to address emergent vulnerabilities.