### PR TITLE
Avoid duplicated archive-mirrors: field in the repo file

### DIFF
--- a/bin/opam-web.sh
+++ b/bin/opam-web.sh
@@ -30,7 +30,12 @@ redirect: [
   "https://${BASEURL}/1.2.2" { opam-version < "2.0~" }
 ]
 EOF
+# Remove the archive-mirrors field to avoid duplication when 'opam admin cache' below will add archive-mirrors: "cache"
+sed '/^archive-mirrors: /d' repo > repo.tmp
+mv repo.tmp repo
+# Adds archive-mirrors: "cache" to the repo file
 opam admin cache --link=archives /cache
+# Adds the 'stamp' fields to the repo file
 opam admin index --minimal-urls-txt
 
 cp -r /usr/local/share/opam2web/content /tmp/


### PR DESCRIPTION
If opam-repository were to add `archive-mirrors` to its `repo` file, we would end up with a repo file with:
```
archive-mirrors: ["cache" "https://opam.ocaml.org/cache"]
```
which is redundant in case a url is missing from the cache.

To avoid this we can simply remove the previous version and stay with the current `archive-mirrors: "cache"` added by `opam admin cache`.