### PR TITLE
Add a link to documentation on ocaml.org

### DIFF
--- a/ext/css/opam2web.css
+++ b/ext/css/opam2web.css
@@ -68,18 +68,15 @@ table.package-info > tbody > tr:first-child > td {
   border-top: 0;
 }
 
-span.versions {
+span.title-group {
   margin-left: 2ex;
-  vertical-align: middle;
+  vertical-align: top;
   font-size: 0.5em;
   font-weight: normal;
 }
 
-span.doc_button {
+span.title-group > .btn {
   margin-left: 2ex;
-  vertical-align: middle;
-  font-size: 0.5em;
-  font-weight: normal;
 }
 
 span.package-version {

--- a/ext/css/opam2web.css
+++ b/ext/css/opam2web.css
@@ -73,6 +73,12 @@ span.versions {
   vertical-align: text-top;
 }
 
+span.doc_button {
+  margin-left: 2ex;
+  vertical-align: middle;
+  font-size: 0.5em;
+}
+
 span.package-version {
   font-weight: bold;
   margin-left: 0.2em;

--- a/ext/css/opam2web.css
+++ b/ext/css/opam2web.css
@@ -70,13 +70,16 @@ table.package-info > tbody > tr:first-child > td {
 
 span.versions {
   margin-left: 2ex;
-  vertical-align: text-top;
+  vertical-align: middle;
+  font-size: 0.5em;
+  font-weight: normal;
 }
 
 span.doc_button {
   margin-left: 2ex;
   vertical-align: middle;
   font-size: 0.5em;
+  font-weight: normal;
 }
 
 span.package-version {

--- a/ext/css/opam2web.css
+++ b/ext/css/opam2web.css
@@ -71,8 +71,9 @@ table.package-info > tbody > tr:first-child > td {
 span.title-group {
   margin-left: 2ex;
   vertical-align: top;
-  font-size: 0.5em;
+  font-size: 0.55em;
   font-weight: normal;
+  color: #999999;
 }
 
 span.title-group > .btn {

--- a/src/o2wPackage.ml
+++ b/src/o2wPackage.ml
@@ -209,7 +209,7 @@ let to_html ~prefix univ pkg =
       Uri.of_string @@
       "https://ocaml.org/p/" ^ name ^ "/" ^ version ^ "/doc/index.html"
     in
-    Html.(a ~href (string "Documentation on ocaml.org"))
+    Html.(a ~cls:"btn" ~href (string "Documentation on ocaml.org"))
   in
   let pkg_descr =
     let to_html = function
@@ -480,8 +480,8 @@ let to_html ~prefix univ pkg =
   let repo_edit = repo_edit +! Html.empty in
   Html.(
     h2 (string (OpamPackage.Name.to_string name) ++
-        span ~cls:"versions" (string "version " ++ version_links) ++
-        span ~cls:"doc_button" doc_button)
+        span ~cls:"title-group" (
+          string "version " ++ version_links ++ doc_button))
     @ div ~cls:"row"
         (div ~cls:"span9"
            (div ~cls:"well" pkg_descr

--- a/src/o2wPackage.ml
+++ b/src/o2wPackage.ml
@@ -480,7 +480,7 @@ let to_html ~prefix univ pkg =
   let repo_edit = repo_edit +! Html.empty in
   Html.(
     h2 (string (OpamPackage.Name.to_string name) ++
-        small (span ~cls:"versions" (string "version " ++ version_links)) ++
+        span ~cls:"versions" (string "version " ++ version_links) ++
         span ~cls:"doc_button" doc_button)
     @ div ~cls:"row"
         (div ~cls:"span9"

--- a/src/o2wPackage.ml
+++ b/src/o2wPackage.ml
@@ -168,18 +168,18 @@ let to_html ~prefix univ pkg =
   let {name; version} = pkg in
   let pkg = OpamPackage.create pkg.name pkg.version in
   let pkg_opam = OpamSwitchState.opam univ.st pkg in
+  let pkg_latest_version =
+    let version_set = OpamPackage.versions_of_name univ.st.packages pkg.name in
+    OpamPackage.Version.Set.max_elt version_set
+  in
   let version_links =
-    let version_set =
-      OpamPackage.versions_of_name univ.st.packages pkg.name
-    in
-    let latest = OpamPackage.Version.Set.max_elt version_set in
     let versions =
         (OpamPackage.versions_of_name univ.st.packages pkg.name)
     in
     let print_v v =
       Html.span ~cls:"package-version"
         (Html.string (OpamPackage.Version.to_string v)) ++
-      if v = latest then Html.string " (latest)"
+      if v = pkg_latest_version then Html.string " (latest)"
       else Html.empty
     in
     Html.div ~cls:"btn-group" @@
@@ -198,6 +198,18 @@ let to_html ~prefix univ pkg =
           else
             Html.li (Html.a ~href (print_v version)))
        (OpamPackage.Version.Set.elements versions))
+  in
+  let doc_button =
+    let name = OpamPackage.Name.to_string name in
+    let version =
+      if pkg.version = pkg_latest_version then "latest"
+      else OpamPackage.Version.to_string pkg.version
+    in
+    let href =
+      Uri.of_string @@
+      "https://ocaml.org/p/" ^ name ^ "/" ^ version ^ "/doc/index.html"
+    in
+    Html.(a ~href (string "Documentation on ocaml.org"))
   in
   let pkg_descr =
     let to_html = function
@@ -468,7 +480,8 @@ let to_html ~prefix univ pkg =
   let repo_edit = repo_edit +! Html.empty in
   Html.(
     h2 (string (OpamPackage.Name.to_string name) ++
-        small (span ~cls:"versions" (string "version " ++ version_links)))
+        small (span ~cls:"versions" (string "version " ++ version_links)) ++
+        span ~cls:"doc_button" doc_button)
     @ div ~cls:"row"
         (div ~cls:"span9"
            (div ~cls:"well" pkg_descr


### PR DESCRIPTION
Beginners couldn't discover the online documentation because `opam.ocaml.org` ranks higher in search engines than `ocaml.org/p`. I propose to add a link to the documentation on ocaml.org.